### PR TITLE
Add regex to remove variants of `1=1` from query terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This project adheres to
 [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Add regex to remove variants of `1=1` from query terms sent to AGO search
+
 ## [1.0.0] - 2019-01-02
 Initial release of a ArcGIS Online and Portal search provider.
 

--- a/model.js
+++ b/model.js
@@ -98,7 +98,8 @@ Model.prototype.getData = function (req, callback) {
 
   
   // TODO: ensure appropriate quotes for Search in Online
-  query.q = (req.query.where || '*').replace(/\s+=\s+/g, ':').replace(/'/g, '"')
+  // Remove any variant of 1=1 as it is not recognized by AGO search; replace = with; replace and ' with "
+  query.q = (req.query.where || '*').replace(/1=1|(\(1=1\))|(AND\s1=1)|(AND\s\(1=1\))/g, '').replace(/\s+=\s+/g, ':').replace(/'/g, '"').replace(/[ \t]+$/, '')
 
   query.num = req.query.resultRecordCount || 5000
   query.start = req.query.resultOffset || 1


### PR DESCRIPTION
 Add regex to remove variants of `1=1` from query terms sent to AGO search