### PR TITLE
Log portal requests when logLevel is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file. This project adheres to
 [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* Support to set log level
+* Log portal url whenever portal request is made 
+
 ## [2.0.2] - 2023-03-31
 ### Added
 * Support for stringifield valid geometry JSON object in request query

--- a/src/model.js
+++ b/src/model.js
@@ -18,8 +18,9 @@ const PORTAL_ENDPOINTS = {
 
 class ArcgisSearchModel {
   constructor(koop, options = {}) {
-    this.log = koop.log;
+    this.log = koop.logger;
     this.ttl = options.ttl || 0;
+    this.logLevel = options.logLevel;
     this.portalUrl = PORTAL_ENDPOINTS[options.portalEnv] || PORTAL_ENDPOINTS['prod'];
     this.userAgent = options.userAgent && setUserAgentForPortalRequest(options.userAgent);
   }
@@ -29,6 +30,9 @@ class ArcgisSearchModel {
       validateRequestQuery(req.query);
       const portalQuery = buildPortalQuery(req.query, this.log);
       const items = await getPortalItems(this.portalUrl, portalQuery, MAX_PAGE_SIZE);
+      if (this.logLevel) {
+        this.log[this.logLevel](`Request made to ${this.portalUrl}`);
+      }
       const geojson = getGeoJson(items, FIELDS_DEFINITION);
 
       geojson.ttl = this.ttl;

--- a/src/model.spec.js
+++ b/src/model.spec.js
@@ -517,4 +517,137 @@ describe('ArcgisSearchModel', () => {
       expect(geojson.features.length).toBe(46);
     });
   });
+
+  it('should log with portal url when request to arcgis portal is made and logLevel is specified', async () => {
+    const req = {
+      query: {
+        f: "json",
+        where: "typekeywords = 'hubSite'",
+        returnGeometry: true,
+        spatialRel: "esriSpatialRelIntersects",
+        maxAllowableOffset: 39135,
+        geometry: {
+          xmin: -20037508.342788905,
+          ymin: 20037508.342788905,
+          xmax: -0.000004857778549194336,
+          ymax: 40075016.68557295,
+          spatialReference: {
+            wkid: 102100,
+          },
+        },
+        geometryType: "esriGeometryEnvelope",
+        inSR: 102100,
+        outFields: "*",
+        outSR: 102100
+      }
+    };
+
+    const firstPagePortalQuery = {
+      f: "json",
+      q: "typekeywords:\"hubSite\"",
+      num: 100,
+      start: 1,
+      bbox: "-179.99999999999696,85.05112877980633,-4.363816717609226e-11,89.78600707473662",
+    };
+
+    nock('http://www.arcgis.com')
+      .get(`/sharing/rest/search?${serializeQueryParams(firstPagePortalQuery)}`)
+      .reply(200, withinLimitResponseFixture);
+
+    const koopLogger = {
+      info(msg) {
+        return true;
+      },
+    };
+
+    const model = new ArcgisSearchModel({ logger: koopLogger }, { logLevel: 'info' });
+    const loggerSpy = jest.spyOn(model.log, 'info');
+    await model.getData(req, (err, geojson) => {
+      expect(geojson).toBeDefined();
+      expect(geojson.features.length).toBe(46);
+
+      expect(geojson.metadata).toBeDefined();
+      expect(geojson.metadata).toStrictEqual({
+        name: 'ArcGIS Search',
+        description: 'Search content in ArcGIS Online',
+        displayField: 'title',
+        fields: FIELDS_DEFINITION,
+        geometryType: 'Polygon',
+        idField: 'itemIdHash'
+      });
+
+      expect(geojson.type).toBe('FeatureCollection');
+      expect(Array.isArray(geojson.features)).toBe(true);
+      expect(geojson.features.length).toBe(46);
+      
+    });
+    expect(loggerSpy).toHaveBeenCalled();
+    expect(loggerSpy).toHaveBeenCalledWith('Request made to http://www.arcgis.com/sharing/rest/search');
+  });
+
+  it('should not log anything when request to arcgis portal is made and logLevel is not specified', async () => {
+    const req = {
+      query: {
+        f: "json",
+        where: "typekeywords = 'hubSite'",
+        returnGeometry: true,
+        spatialRel: "esriSpatialRelIntersects",
+        maxAllowableOffset: 39135,
+        geometry: {
+          xmin: -20037508.342788905,
+          ymin: 20037508.342788905,
+          xmax: -0.000004857778549194336,
+          ymax: 40075016.68557295,
+          spatialReference: {
+            wkid: 102100,
+          },
+        },
+        geometryType: "esriGeometryEnvelope",
+        inSR: 102100,
+        outFields: "*",
+        outSR: 102100
+      }
+    };
+
+    const firstPagePortalQuery = {
+      f: "json",
+      q: "typekeywords:\"hubSite\"",
+      num: 100,
+      start: 1,
+      bbox: "-179.99999999999696,85.05112877980633,-4.363816717609226e-11,89.78600707473662",
+    };
+
+    nock('http://www.arcgis.com')
+      .get(`/sharing/rest/search?${serializeQueryParams(firstPagePortalQuery)}`)
+      .reply(200, withinLimitResponseFixture);
+      
+    const koopLogger = {
+      info(msg) {
+        return true;
+      },
+    };
+
+    const model = new ArcgisSearchModel({ logger: koopLogger }, {});
+    const loggerSpy = jest.spyOn(model.log, 'info');
+    await model.getData(req, (err, geojson) => {
+      expect(geojson).toBeDefined();
+      expect(geojson.features.length).toBe(46);
+
+      expect(geojson.metadata).toBeDefined();
+      expect(geojson.metadata).toStrictEqual({
+        name: 'ArcGIS Search',
+        description: 'Search content in ArcGIS Online',
+        displayField: 'title',
+        fields: FIELDS_DEFINITION,
+        geometryType: 'Polygon',
+        idField: 'itemIdHash'
+      });
+
+      expect(geojson.type).toBe('FeatureCollection');
+      expect(Array.isArray(geojson.features)).toBe(true);
+      expect(geojson.features.length).toBe(46);
+      
+    });
+    expect(loggerSpy).not.toHaveBeenCalled();
+  });
 });

--- a/src/model.spec.js
+++ b/src/model.spec.js
@@ -581,7 +581,7 @@ describe('ArcgisSearchModel', () => {
       expect(geojson.features.length).toBe(46);
       
     });
-    expect(loggerSpy).toHaveBeenCalled();
+    expect(loggerSpy).toHaveBeenCalledTimes(1);
     expect(loggerSpy).toHaveBeenCalledWith('Request made to http://www.arcgis.com/sharing/rest/search');
   });
 
@@ -620,7 +620,7 @@ describe('ArcgisSearchModel', () => {
     nock('http://www.arcgis.com')
       .get(`/sharing/rest/search?${serializeQueryParams(firstPagePortalQuery)}`)
       .reply(200, withinLimitResponseFixture);
-      
+
     const koopLogger = {
       info(msg) {
         return true;


### PR DESCRIPTION
This PR adds option to set `logLevel` and logs whenever request to Arcgis search portal is made with portal url.

Related https://devtopia.esri.com/dc/hub/issues/6489