### PR TITLE
skip request to portal

### DIFF
--- a/src/model.spec.js
+++ b/src/model.spec.js
@@ -15,28 +15,35 @@ describe('ArcgisSearchModel', () => {
     jest.resetModules();
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should get batched portal items in geojson format when total item count is greater than 100', async () => {
-    const req = {
-      query: {
-        f: "json",
-        where: "typekeywords = 'hubSite'",
-        returnGeometry: true,
-        spatialRel: "esriSpatialRelIntersects",
-        maxAllowableOffset: 39135,
-        geometry: {
-          xmin: -13135699.913606282,
-          ymin: 3763310.6271446524,
-          xmax: -12913060.932019735,
-          ymax: 4028802.0261344067,
-          spatialReference: {
-            wkid: 102100,
-          },
+    const query = {
+      f: "json",
+      where: "typekeywords = 'hubSite'",
+      returnGeometry: true,
+      spatialRel: "esriSpatialRelIntersects",
+      maxAllowableOffset: 39135,
+      geometry: {
+        xmin: -13135699.913606282,
+        ymin: 3763310.6271446524,
+        xmax: -12913060.932019735,
+        ymax: 4028802.0261344067,
+        spatialReference: {
+          wkid: 102100,
         },
-        geometryType: "esriGeometryEnvelope",
-        inSR: 102100,
-        outFields: "*",
-        outSR: 102100,
-      }
+      },
+      geometryType: "esriGeometryEnvelope",
+      inSR: 102100,
+      outFields: "*",
+      outSR: 102100,
+    };
+
+    const req = {
+      originalUrl: `/api/v3/connectors/arcgissearch/rest/services/featureserver/0/query?${serializeQueryParams(query)}`,
+      query
     };
 
     const firstPagePortalQuery = {
@@ -64,6 +71,7 @@ describe('ArcgisSearchModel', () => {
       .reply(200, withinLimitResponseFixture);
 
     const model = new ArcgisSearchModel({});
+    const getItemsFromPortalSpy = jest.spyOn(model, 'getItemsFromPortal');
 
     await model.getData(req, (err, geojson) => {
       expect(geojson).toBeDefined();
@@ -84,30 +92,34 @@ describe('ArcgisSearchModel', () => {
       expect(geojson.type).toBe('FeatureCollection');
       expect(geojson.features).toStrictEqual(exceeedLimitGeojsonFixture);
     });
+    expect(getItemsFromPortalSpy).toHaveBeenCalled();
   });
 
   it('should only get first page portal items in geojson format when total item count is less than 100', async () => {
-    const req = {
-      query: {
-        f: "json",
-        where: "typekeywords = 'hubSite'",
-        returnGeometry: true,
-        spatialRel: "esriSpatialRelIntersects",
-        maxAllowableOffset: 39135,
-        geometry: {
-          xmin: -20037508.342788905,
-          ymin: 20037508.342788905,
-          xmax: -0.000004857778549194336,
-          ymax: 40075016.68557295,
-          spatialReference: {
-            wkid: 102100,
-          },
+    const query = {
+      f: "json",
+      where: "typekeywords = 'hubSite'",
+      returnGeometry: true,
+      spatialRel: "esriSpatialRelIntersects",
+      maxAllowableOffset: 39135,
+      geometry: {
+        xmin: -20037508.342788905,
+        ymin: 20037508.342788905,
+        xmax: -0.000004857778549194336,
+        ymax: 40075016.68557295,
+        spatialReference: {
+          wkid: 102100,
         },
-        geometryType: "esriGeometryEnvelope",
-        inSR: 102100,
-        outFields: "*",
-        outSR: 102100
-      }
+      },
+      geometryType: "esriGeometryEnvelope",
+      inSR: 102100,
+      outFields: "*",
+      outSR: 102100
+    };
+
+    const req = {
+      originalUrl: `/api/v3/connectors/arcgissearch/rest/services/featureserver/0/query?${serializeQueryParams(query)}`,
+      query
     };
 
     const firstPagePortalQuery = {
@@ -123,11 +135,10 @@ describe('ArcgisSearchModel', () => {
       .reply(200, withinLimitResponseFixture);
 
     const model = new ArcgisSearchModel({});
+    const getItemsFromPortalSpy = jest.spyOn(model, 'getItemsFromPortal');
 
     await model.getData(req, (err, geojson) => {
       expect(geojson).toBeDefined();
-      expect(geojson.features.length).toBe(46);
-
       expect(geojson.metadata).toBeDefined();
       expect(geojson.metadata).toStrictEqual({
         name: 'ArcGIS Search',
@@ -143,30 +154,34 @@ describe('ArcgisSearchModel', () => {
       expect(geojson.features.length).toBe(46);
       expect(geojson.features).toStrictEqual(withinLimitGeojsonFixture);
     });
+    expect(getItemsFromPortalSpy).toHaveBeenCalled();
   });
 
   it('should throw error if request to arcgis portal fails', async () => {
-    const req = {
-      query: {
-        f: "json",
-        where: "typekeywords = 'hubSite'",
-        returnGeometry: true,
-        spatialRel: "esriSpatialRelIntersects",
-        maxAllowableOffset: 39135,
-        geometry: {
-          xmin: -20037508.342788905,
-          ymin: 20037508.342788905,
-          xmax: -0.000004857778549194336,
-          ymax: 40075016.68557295,
-          spatialReference: {
-            wkid: 102100,
-          },
+    const query = {
+      f: "json",
+      where: "typekeywords = 'hubSite'",
+      returnGeometry: true,
+      spatialRel: "esriSpatialRelIntersects",
+      maxAllowableOffset: 39135,
+      geometry: {
+        xmin: -20037508.342788905,
+        ymin: 20037508.342788905,
+        xmax: -0.000004857778549194336,
+        ymax: 40075016.68557295,
+        spatialReference: {
+          wkid: 102100,
         },
-        geometryType: "esriGeometryEnvelope",
-        inSR: 102100,
-        outFields: "*",
-        outSR: 102100
-      }
+      },
+      geometryType: "esriGeometryEnvelope",
+      inSR: 102100,
+      outFields: "*",
+      outSR: 102100
+    };
+
+    const req = {
+      originalUrl: `/api/v3/connectors/arcgissearch/rest/services/featureserver/0/query?${serializeQueryParams(query)}`,
+      query
     };
 
     const firstPagePortalQuery = {
@@ -195,27 +210,30 @@ describe('ArcgisSearchModel', () => {
     const { validateRequestQuery } = require('../src/helpers/validate-request-query');
     validateRequestQuery.mockImplementation(() => { throw new ArcgisSearchProviderError(); });
     const Model = require('../src/model');
-    const req = {
-      query: {
-        f: "json",
-        where: "typekeywords = 'hubSite'",
-        returnGeometry: true,
-        spatialRel: "esriSpatialRelIntersects",
-        maxAllowableOffset: 39135,
-        geometry: {
-          xmin: -20037508.342788905,
-          ymin: 20037508.342788905,
-          xmax: -0.000004857778549194336,
-          ymax: 40075016.68557295,
-          spatialReference: {
-            wkid: 102100,
-          },
+    const query = {
+      f: "json",
+      where: "typekeywords = 'hubSite'",
+      returnGeometry: true,
+      spatialRel: "esriSpatialRelIntersects",
+      maxAllowableOffset: 39135,
+      geometry: {
+        xmin: -20037508.342788905,
+        ymin: 20037508.342788905,
+        xmax: -0.000004857778549194336,
+        ymax: 40075016.68557295,
+        spatialReference: {
+          wkid: 102100,
         },
-        geometryType: "esriGeometryEnvelope",
-        inSR: 102100,
-        outFields: "*",
-        outSR: 102100
-      }
+      },
+      geometryType: "esriGeometryEnvelope",
+      inSR: 102100,
+      outFields: "*",
+      outSR: 102100
+    };
+
+    const req = {
+      originalUrl: `/api/v3/connectors/arcgissearch/rest/services/featureserver/0/query?${serializeQueryParams(query)}`,
+      query
     };
 
     const model = new Model({});
@@ -226,27 +244,30 @@ describe('ArcgisSearchModel', () => {
   });
 
   it('should set portal request user agent when user agent is passed in options via constructor', async () => {
-    const req = {
-      query: {
-        f: "json",
-        where: "typekeywords = 'hubSite'",
-        returnGeometry: true,
-        spatialRel: "esriSpatialRelIntersects",
-        maxAllowableOffset: 39135,
-        geometry: {
-          xmin: -20037508.342788905,
-          ymin: 20037508.342788905,
-          xmax: -0.000004857778549194336,
-          ymax: 40075016.68557295,
-          spatialReference: {
-            wkid: 102100,
-          },
+    const query = {
+      f: "json",
+      where: "typekeywords = 'hubSite'",
+      returnGeometry: true,
+      spatialRel: "esriSpatialRelIntersects",
+      maxAllowableOffset: 39135,
+      geometry: {
+        xmin: -20037508.342788905,
+        ymin: 20037508.342788905,
+        xmax: -0.000004857778549194336,
+        ymax: 40075016.68557295,
+        spatialReference: {
+          wkid: 102100,
         },
-        geometryType: "esriGeometryEnvelope",
-        inSR: 102100,
-        outFields: "*",
-        outSR: 102100
-      }
+      },
+      geometryType: "esriGeometryEnvelope",
+      inSR: 102100,
+      outFields: "*",
+      outSR: 102100
+    };
+
+    const req = {
+      originalUrl: `/api/v3/connectors/arcgissearch/rest/services/featureserver/0/query?${serializeQueryParams(query)}`,
+      query
     };
 
     const firstPagePortalQuery = {
@@ -285,27 +306,30 @@ describe('ArcgisSearchModel', () => {
   });
 
   it('should set ttl in geojson when ttl is passed in options via constructor', async () => {
-    const req = {
-      query: {
-        f: "json",
-        where: "typekeywords = 'hubSite'",
-        returnGeometry: true,
-        spatialRel: "esriSpatialRelIntersects",
-        maxAllowableOffset: 39135,
-        geometry: {
-          xmin: -20037508.342788905,
-          ymin: 20037508.342788905,
-          xmax: -0.000004857778549194336,
-          ymax: 40075016.68557295,
-          spatialReference: {
-            wkid: 102100,
-          },
+    const query = {
+      f: "json",
+      where: "typekeywords = 'hubSite'",
+      returnGeometry: true,
+      spatialRel: "esriSpatialRelIntersects",
+      maxAllowableOffset: 39135,
+      geometry: {
+        xmin: -20037508.342788905,
+        ymin: 20037508.342788905,
+        xmax: -0.000004857778549194336,
+        ymax: 40075016.68557295,
+        spatialReference: {
+          wkid: 102100,
         },
-        geometryType: "esriGeometryEnvelope",
-        inSR: 102100,
-        outFields: "*",
-        outSR: 102100
-      }
+      },
+      geometryType: "esriGeometryEnvelope",
+      inSR: 102100,
+      outFields: "*",
+      outSR: 102100
+    };
+
+    const req = {
+      originalUrl: `/api/v3/connectors/arcgissearch/rest/services/featureserver/0/query?${serializeQueryParams(query)}`,
+      query
     };
 
     const firstPagePortalQuery = {
@@ -346,28 +370,32 @@ describe('ArcgisSearchModel', () => {
   });
 
   it('should set portal endpoint when portalEnv dev is passed in options via constructor', async () => {
-    const req = {
-      query: {
-        f: "json",
-        where: "typekeywords = 'hubSite'",
-        returnGeometry: true,
-        spatialRel: "esriSpatialRelIntersects",
-        maxAllowableOffset: 39135,
-        geometry: {
-          xmin: -20037508.342788905,
-          ymin: 20037508.342788905,
-          xmax: -0.000004857778549194336,
-          ymax: 40075016.68557295,
-          spatialReference: {
-            wkid: 102100,
-          },
+    const query = {
+      f: "json",
+      where: "typekeywords = 'hubSite'",
+      returnGeometry: true,
+      spatialRel: "esriSpatialRelIntersects",
+      maxAllowableOffset: 39135,
+      geometry: {
+        xmin: -20037508.342788905,
+        ymin: 20037508.342788905,
+        xmax: -0.000004857778549194336,
+        ymax: 40075016.68557295,
+        spatialReference: {
+          wkid: 102100,
         },
-        geometryType: "esriGeometryEnvelope",
-        inSR: 102100,
-        outFields: "*",
-        outSR: 102100
-      }
+      },
+      geometryType: "esriGeometryEnvelope",
+      inSR: 102100,
+      outFields: "*",
+      outSR: 102100
     };
+
+    const req = {
+      originalUrl: `/api/v3/connectors/arcgissearch/rest/services/featureserver/0/query?${serializeQueryParams(query)}`,
+      query
+    };
+
 
     const firstPagePortalQuery = {
       f: "json",
@@ -404,27 +432,30 @@ describe('ArcgisSearchModel', () => {
   });
 
   it('should set portal endpoint when portalEnv qa is passed in options via constructor', async () => {
-    const req = {
-      query: {
-        f: "json",
-        where: "typekeywords = 'hubSite'",
-        returnGeometry: true,
-        spatialRel: "esriSpatialRelIntersects",
-        maxAllowableOffset: 39135,
-        geometry: {
-          xmin: -20037508.342788905,
-          ymin: 20037508.342788905,
-          xmax: -0.000004857778549194336,
-          ymax: 40075016.68557295,
-          spatialReference: {
-            wkid: 102100,
-          },
+    const query = {
+      f: "json",
+      where: "typekeywords = 'hubSite'",
+      returnGeometry: true,
+      spatialRel: "esriSpatialRelIntersects",
+      maxAllowableOffset: 39135,
+      geometry: {
+        xmin: -20037508.342788905,
+        ymin: 20037508.342788905,
+        xmax: -0.000004857778549194336,
+        ymax: 40075016.68557295,
+        spatialReference: {
+          wkid: 102100,
         },
-        geometryType: "esriGeometryEnvelope",
-        inSR: 102100,
-        outFields: "*",
-        outSR: 102100
-      }
+      },
+      geometryType: "esriGeometryEnvelope",
+      inSR: 102100,
+      outFields: "*",
+      outSR: 102100
+    };
+
+    const req = {
+      originalUrl: `/api/v3/connectors/arcgissearch/rest/services/featureserver/0/query?${serializeQueryParams(query)}`,
+      query
     };
 
     const firstPagePortalQuery = {
@@ -462,27 +493,30 @@ describe('ArcgisSearchModel', () => {
   });
 
   it('should set default prod portal endpoint when portalUrl is not passed in options via constructor', async () => {
-    const req = {
-      query: {
-        f: "json",
-        where: "typekeywords = 'hubSite'",
-        returnGeometry: true,
-        spatialRel: "esriSpatialRelIntersects",
-        maxAllowableOffset: 39135,
-        geometry: {
-          xmin: -20037508.342788905,
-          ymin: 20037508.342788905,
-          xmax: -0.000004857778549194336,
-          ymax: 40075016.68557295,
-          spatialReference: {
-            wkid: 102100,
-          },
+    const query = {
+      f: "json",
+      where: "typekeywords = 'hubSite'",
+      returnGeometry: true,
+      spatialRel: "esriSpatialRelIntersects",
+      maxAllowableOffset: 39135,
+      geometry: {
+        xmin: -20037508.342788905,
+        ymin: 20037508.342788905,
+        xmax: -0.000004857778549194336,
+        ymax: 40075016.68557295,
+        spatialReference: {
+          wkid: 102100,
         },
-        geometryType: "esriGeometryEnvelope",
-        inSR: 102100,
-        outFields: "*",
-        outSR: 102100
-      }
+      },
+      geometryType: "esriGeometryEnvelope",
+      inSR: 102100,
+      outFields: "*",
+      outSR: 102100
+    };
+
+    const req = {
+      originalUrl: `/api/v3/connectors/arcgissearch/rest/services/featureserver/0/query?${serializeQueryParams(query)}`,
+      query
     };
 
     const firstPagePortalQuery = {
@@ -519,27 +553,30 @@ describe('ArcgisSearchModel', () => {
   });
 
   it('should not log anything when request to arcgis portal is made and logLevel is not specified', async () => {
-    const req = {
-      query: {
-        f: "json",
-        where: "typekeywords = 'hubSite'",
-        returnGeometry: true,
-        spatialRel: "esriSpatialRelIntersects",
-        maxAllowableOffset: 39135,
-        geometry: {
-          xmin: -20037508.342788905,
-          ymin: 20037508.342788905,
-          xmax: -0.000004857778549194336,
-          ymax: 40075016.68557295,
-          spatialReference: {
-            wkid: 102100,
-          },
+    const query = {
+      f: "json",
+      where: "typekeywords = 'hubSite'",
+      returnGeometry: true,
+      spatialRel: "esriSpatialRelIntersects",
+      maxAllowableOffset: 39135,
+      geometry: {
+        xmin: -20037508.342788905,
+        ymin: 20037508.342788905,
+        xmax: -0.000004857778549194336,
+        ymax: 40075016.68557295,
+        spatialReference: {
+          wkid: 102100,
         },
-        geometryType: "esriGeometryEnvelope",
-        inSR: 102100,
-        outFields: "*",
-        outSR: 102100
-      }
+      },
+      geometryType: "esriGeometryEnvelope",
+      inSR: 102100,
+      outFields: "*",
+      outSR: 102100
+    };
+
+    const req = {
+      originalUrl: `/api/v3/connectors/arcgissearch/rest/services/featureserver/0/query?${serializeQueryParams(query)}`,
+      query
     };
 
     const firstPagePortalQuery = {
@@ -585,27 +622,30 @@ describe('ArcgisSearchModel', () => {
   });
 
   it('should log with portal url when request to arcgis portal is made and logLevel is specified', async () => {
-    const req = {
-      query: {
-        f: "json",
-        where: "typekeywords = 'hubSite'",
-        returnGeometry: true,
-        spatialRel: "esriSpatialRelIntersects",
-        maxAllowableOffset: 39135,
-        geometry: {
-          xmin: -13135699.913606282,
-          ymin: 3763310.6271446524,
-          xmax: -12913060.932019735,
-          ymax: 4028802.0261344067,
-          spatialReference: {
-            wkid: 102100,
-          },
+    const query = {
+      f: "json",
+      where: "typekeywords = 'hubSite'",
+      returnGeometry: true,
+      spatialRel: "esriSpatialRelIntersects",
+      maxAllowableOffset: 39135,
+      geometry: {
+        xmin: -13135699.913606282,
+        ymin: 3763310.6271446524,
+        xmax: -12913060.932019735,
+        ymax: 4028802.0261344067,
+        spatialReference: {
+          wkid: 102100,
         },
-        geometryType: "esriGeometryEnvelope",
-        inSR: 102100,
-        outFields: "*",
-        outSR: 102100,
-      }
+      },
+      geometryType: "esriGeometryEnvelope",
+      inSR: 102100,
+      outFields: "*",
+      outSR: 102100,
+    };
+
+    const req = {
+      originalUrl: `/api/v3/connectors/arcgissearch/rest/services/featureserver/0/query?${serializeQueryParams(query)}`,
+      query
     };
 
     const firstPagePortalQuery = {
@@ -629,7 +669,8 @@ describe('ArcgisSearchModel', () => {
       .reply(200, exceeedLimitResponseFixture);
 
     nock('https://www.arcgis.com', {
-      authorization: 'Basic Auth'})
+      authorization: 'Basic Auth'
+    })
       .get(`/sharing/rest/search?${serializeQueryParams(secondPagePortalQuery)}`)
       .reply(200, withinLimitResponseFixture);
 
@@ -664,6 +705,162 @@ describe('ArcgisSearchModel', () => {
     expect(loggerSpy).toHaveBeenCalledTimes(2);
     expect(loggerSpy).toHaveBeenNthCalledWith(1, `Request made to https://www.arcgis.com/sharing/rest/search?${serializeQueryParams(firstPagePortalQuery)}`);
     expect(loggerSpy).toHaveBeenNthCalledWith(2, `Request made to https://www.arcgis.com/sharing/rest/search?${serializeQueryParams(secondPagePortalQuery)}`);
+
+  });
+
+  it('should not make request to portal and throw error if request endpoint contains invalid query', async () => {
+    const query = {
+      f: "json",
+    };
+
+    const req = {
+      originalUrl: `/api/v3/connectors/arcgissearch/rest/services/featureserver/0/query?fjson`,
+      query
+    };
+
+    const firstPagePortalQuery = {
+      f: "json",
+      q: "typekeywords:\"hubSite\"",
+      num: 100,
+      start: 1,
+      bbox: "-179.99999999999696,85.05112877980633,-4.363816717609226e-11,89.78600707473662",
+    };
+
+    nock('https://www.arcgis.com')
+      .get(`/sharing/rest/search?${serializeQueryParams(firstPagePortalQuery)}`)
+      .reply(200, withinLimitResponseFixture);
+
+    const model = new ArcgisSearchModel({});
+    const getItemsFromPortalSpy = jest.spyOn(model, 'getItemsFromPortal');
+    await model.getData(req, (err, geojson) => {
+      expect(geojson).toBeUndefined();
+      expect(err.statusCode).toBe(400);
+      expect(err.message).toBe('Invalid query');
+      expect(err).toBeInstanceOf(ArcgisSearchProviderError);
+    });
+    expect(getItemsFromPortalSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not make request to portal if request url is for feature server metadata with layer id', async () => {
+    const req = {
+      originalUrl: `/api/v3/connectors/arcgissearch/rest/services/featureserver/0/`,
+      query: {}
+    };
+
+    const firstPagePortalQuery = {
+      f: "json",
+      q: "typekeywords:\"hubSite\"",
+      num: 100,
+      start: 1,
+      bbox: "-179.99999999999696,85.05112877980633,-4.363816717609226e-11,89.78600707473662",
+    };
+
+    nock('https://www.arcgis.com')
+      .get(`/sharing/rest/search?${serializeQueryParams(firstPagePortalQuery)}`)
+      .reply(200, withinLimitResponseFixture);
+
+    const model = new ArcgisSearchModel({});
+    const getItemsFromPortalSpy = jest.spyOn(model, 'getItemsFromPortal');
+
+    await model.getData(req, (err, geojson) => {
+      expect(geojson).toBeDefined();
+      expect(geojson.metadata).toBeDefined();
+      expect(geojson.metadata).toStrictEqual({
+        name: 'ArcGIS Search',
+        description: 'Search content in ArcGIS Online',
+        displayField: 'title',
+        fields: FIELDS_DEFINITION,
+        geometryType: 'Polygon',
+        idField: 'itemIdHash'
+      });
+
+      expect(geojson.type).toBe('FeatureCollection');
+      expect(Array.isArray(geojson.features)).toBe(true);
+      expect(geojson.features.length).toBe(0);
+    });
+    expect(getItemsFromPortalSpy).not.toHaveBeenCalled();
+
+  });
+
+  it('should not make request to portal if request url is for feature server metadata without layer id', async () => {
+    const req = {
+      originalUrl: `/api/v3/connectors/arcgissearch/rest/services/featureserver/`,
+      query: {}
+    };
+
+    const firstPagePortalQuery = {
+      f: "json",
+      q: "typekeywords:\"hubSite\"",
+      num: 100,
+      start: 1,
+      bbox: "-179.99999999999696,85.05112877980633,-4.363816717609226e-11,89.78600707473662",
+    };
+
+    nock('https://www.arcgis.com')
+      .get(`/sharing/rest/search?${serializeQueryParams(firstPagePortalQuery)}`)
+      .reply(200, withinLimitResponseFixture);
+
+    const model = new ArcgisSearchModel({});
+    const getItemsFromPortalSpy = jest.spyOn(model, 'getItemsFromPortal');
+
+    await model.getData(req, (err, geojson) => {
+      expect(geojson).toBeDefined();
+      expect(geojson.metadata).toBeDefined();
+      expect(geojson.metadata).toStrictEqual({
+        name: 'ArcGIS Search',
+        description: 'Search content in ArcGIS Online',
+        displayField: 'title',
+        fields: FIELDS_DEFINITION,
+        geometryType: 'Polygon',
+        idField: 'itemIdHash'
+      });
+
+      expect(geojson.type).toBe('FeatureCollection');
+      expect(Array.isArray(geojson.features)).toBe(true);
+      expect(geojson.features.length).toBe(0);
+    });
+    expect(getItemsFromPortalSpy).not.toHaveBeenCalled();
+
+  });
+
+  it('should ignore casing for the requests to feature server metadata', async () => {
+    const req = {
+      originalUrl: `/api/v3/connectors/arcgissearch/rest/services/FeatureServer/`,
+      query: {}
+    };
+
+    const firstPagePortalQuery = {
+      f: "json",
+      q: "typekeywords:\"hubSite\"",
+      num: 100,
+      start: 1,
+      bbox: "-179.99999999999696,85.05112877980633,-4.363816717609226e-11,89.78600707473662",
+    };
+
+    nock('https://www.arcgis.com')
+      .get(`/sharing/rest/search?${serializeQueryParams(firstPagePortalQuery)}`)
+      .reply(200, withinLimitResponseFixture);
+
+    const model = new ArcgisSearchModel({});
+    const getItemsFromPortalSpy = jest.spyOn(model, 'getItemsFromPortal');
+
+    await model.getData(req, (err, geojson) => {
+      expect(geojson).toBeDefined();
+      expect(geojson.metadata).toBeDefined();
+      expect(geojson.metadata).toStrictEqual({
+        name: 'ArcGIS Search',
+        description: 'Search content in ArcGIS Online',
+        displayField: 'title',
+        fields: FIELDS_DEFINITION,
+        geometryType: 'Polygon',
+        idField: 'itemIdHash'
+      });
+
+      expect(geojson.type).toBe('FeatureCollection');
+      expect(Array.isArray(geojson.features)).toBe(true);
+      expect(geojson.features.length).toBe(0);
+    });
+    expect(getItemsFromPortalSpy).not.toHaveBeenCalled();
 
   });
 });


### PR DESCRIPTION
This PR validates the request query and if request query is just a call to feature server metadata or it does not contain valid request query (missing where or geometry), it skips the request to portal.